### PR TITLE
Handle stopping the container on process termination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info
 __pycache__
+build/


### PR DESCRIPTION
- Updated gitignore
- Run the subprocess using asyncio. The previous method replaced the current process with the subprocess, preventing us from catching the termination signals. The asyncio version keeps running in the background and can be stopped gracefully.
- Added a naming convention for the containers: `devcontainer-{pid}` with the PID of the parent process to uniquely identify the container.
- The container is now configured to use host PIDs so that it's subprocesses have the same PID inside and outside of the container
- Configure the container to issue a SIGKILL command when the container is stopped (this is faster to shut down the processes in the container)
- When the parent process receives a termination signal (SIGINT, SIGTERM, SIGQUIT) these are caught, the container is stopped and the asyncio wait will then return so the main script will exit gracefully